### PR TITLE
Fix typo

### DIFF
--- a/docs/fundamentals/hyperparameters.md
+++ b/docs/fundamentals/hyperparameters.md
@@ -103,7 +103,7 @@ ClearML automatically captures TFDefine files, which are used as configuration f
 [Hydra](https://github.com/facebookresearch/hydra) is a module developed by FaceBook AI Research to manage experiments' 
 parameters. Hydra offers the best of both worlds, managing configurations with files while making parameters overridable at runtime.
 
-ClearML logs the Omegaconf which holds all the configuration files, as well as overriden values. 
+ClearML logs the Omegaconf which holds all the configuration files, as well as overridden values. 
 
 Check out the [example code](https://github.com/allegroai/clearml/blob/master/examples/frameworks/hydra/hydra_example.py),
 which demonstrates the creation of a configuration object to which configuration values can be added and overridden using the 


### PR DESCRIPTION
overriden --> overridden (in fundamentals/hyperparameters)