### PR TITLE
Update mlops_first_steps.md

### DIFF
--- a/docs/getting_started/mlops/mlops_first_steps.md
+++ b/docs/getting_started/mlops/mlops_first_steps.md
@@ -30,7 +30,7 @@ pip install clearml-agent
 Connect the Agent to the server by [creating credentials](https://app.community.clear.ml/profile), then run this:
 
 ```bash
-clearml-init
+clearml-agent init
 ```
 
 :::note


### PR DESCRIPTION
I followed the installation instruction `pip install clearml-agent` but met with the error (`clearml-init: command not found`) when executing `clearml-init`. The command `clearml-init` works only after I have configured using `clearml-agent init`. 

Suggest to change `clearml-init` to `clearml-agent init` for consistency.