### PR TITLE
Small updates

### DIFF
--- a/docs/guides/frameworks/pytorch/model_updating.md
+++ b/docs/guides/frameworks/pytorch/model_updating.md
@@ -1,9 +1,9 @@
 ---
-title: Model Updating
+title: PyTorch Model Updating
 ---
 
 The [pytorch_model_update.py](https://github.com/allegroai/clearml/blob/master/examples/frameworks/pytorch/pytorch_model_update.py) 
-example demonstrates training a model and logging it using the [OutputModel](../../references/sdk/model_outputmodel.md) 
+example demonstrates training a model and logging it using the [OutputModel](../../../references/sdk/model_outputmodel.md) 
 class. 
 
 The example does the following:
@@ -13,7 +13,7 @@ The example does the following:
 
 :::note Disabling automatic framework logging
 This example disables the default automatic capturing of PyTorch outputs, to demonstrate how to manually control what is 
-logged from PyTorch. See [this FAQ](../../faq.md#controlling_logging) for more information. 
+logged from PyTorch. See [this FAQ](../../../faq.md#controlling_logging) for more information. 
 ::: 
 
 ## Initialization
@@ -32,9 +32,9 @@ output_model = OutputModel(task=task)
 ```
 
 ## Label Enumeration
-The label enumeration dictionary is logged using the [`Task.connect_label_enumeration`](../../references/sdk/task.md#connect_label_enumeration) 
+The label enumeration dictionary is logged using the [`Task.connect_label_enumeration`](../../../references/sdk/task.md#connect_label_enumeration) 
 method which will update the task’s resulting model information. The current running task is accessed using the 
-[`Task.current_task`](../../references/sdk/task.md#taskcurrent_task) class method.
+[`Task.current_task`](../../../references/sdk/task.md#taskcurrent_task) class method.
 
 ```python
 # store the label enumeration of the training model
@@ -44,13 +44,13 @@ Task.current_task().connect_label_enumeration(enumeration)
 ```
 
 :::note Directly Setting Model Enumeration
-You can set a model’s label enumeration directly using the [`OutputModel.update_labels`](../../references/sdk/model_outputmodel.md#update_labels) 
+You can set a model’s label enumeration directly using the [`OutputModel.update_labels`](../../../references/sdk/model_outputmodel.md#update_labels) 
 method
 :::
 
 ## Model Configuration
 
-Add a configuration dictionary to the model using the [`OutputModel.update_design`](../../references/sdk/model_outputmodel.md#update_design) 
+Add a configuration dictionary to the model using the [`OutputModel.update_design`](../../../references/sdk/model_outputmodel.md#update_design) 
 method. 
 
 ```python
@@ -67,8 +67,8 @@ model.update_design(config_dict=model_config_dict)
 ```
 
 ## Updating Models
-To update a model, use the [OutputModel.update_weights](../../references/sdk/model_outputmodel.md#update_weights) method. 
-This uploads the model to the set storage destination (see [Setting Upload Destination](../../fundamentals/artifacts.md#setting-upload-destination)), 
+To update a model, use the [OutputModel.update_weights](../../../references/sdk/model_outputmodel.md#update_weights) method. 
+This uploads the model to the set storage destination (see [Setting Upload Destination](../../../fundamentals/artifacts.md#setting-upload-destination)), 
 and registers that location to the task as the output model. 
 
 ```python
@@ -83,17 +83,18 @@ if CONDITION:
 ## WebApp
 The model appears in the task’s **ARTIFACTS** tab. 
 
-![Task artifacts](../../img/examples_model_update_artifacts.png)
+![Task artifacts](../../../img/examples_model_update_artifacts.png)
 
-Clicking on the model name takes you to the [model’s page](../../webapp/webapp_model_viewing.md), where you can view the 
+Clicking on the model name takes you to the [model’s page](../../../webapp/webapp_model_viewing.md), where you can view the 
 model’s details and access the model.
 
-![Model page](../../img/examples_model_update_model.png)
+![Model page](../../../img/examples_model_update_model.png)
 
 The model’s **NETWORK** tab displays its configuration.
 
-![Model network tab](../../img/examples_model_update_network.png)
+![Model network tab](../../../img/examples_model_update_network.png)
 
 The model’s **LABELS** tab displays its label enumeration.
 
-![Model labels](../../img/examples_model_update_labels.png)
+![Model labels](../../../img/examples_model_update_labels.png)
+

--- a/docs/guides/reporting/model_config.md
+++ b/docs/guides/reporting/model_config.md
@@ -54,3 +54,7 @@ The model’s **LABELS** tab displays its label enumeration.
 
 ![Model Labels tab](../../img/examples_model_logging_labels.png)
 
+## Additional Example
+
+See [PyTorch Model Updating](../frameworks/pytorch/model_updating.md) for a more robust example, which trains a model, 
+and then logs it with OutputModel.

--- a/docs/guides/reporting/model_updating.md
+++ b/docs/guides/reporting/model_updating.md
@@ -2,7 +2,7 @@
 title: Model Updating
 ---
 
-The [model_update_pytorch.py](https://github.com/allegroai/clearml/blob/master/examples/reporting/model_update_pytorch.py) 
+The [pytorch_model_update.py](https://github.com/allegroai/clearml/blob/master/examples/frameworks/pytorch/pytorch_model_update.py) 
 example demonstrates training a model and logging it using the [OutputModel](../../references/sdk/model_outputmodel.md) 
 class. 
 

--- a/docs/references/clearml_agent_ref.md
+++ b/docs/references/clearml_agent_ref.md
@@ -18,7 +18,7 @@ Use the `build` subcommand to create a worker environment without executing the 
 ```bash
 clearml-agent build [-h] --id TASK_ID [--target TARGET]
                     [--install-globally]
-                    [--docker [DOCKER [DOCKER ...]]]
+                    [--docker [DOCKER [DOCKER ...]]] [--force-docker] 
                     [--python-version PYTHON_VERSION]
                     [--entry-point {reuse_task,clone_task}] [-O]
                     [--git-user GIT_USER] [--git-pass GIT_PASS]
@@ -71,6 +71,15 @@ clearml-agent build [-h] --id TASK_ID [--target TARGET]
     * `reuse` - Overwrite the existing Task data.
     * `clone_task` - Clone the Task, and execute the cloned Task.
         
+---
+
+**`force-docker`**
+
+* Force using the agent-specified docker image (either explicitly in the `--docker` argument or using the agent's 
+  default docker image). If provided, the agent will not use any docker container information stored in the task itself 
+  (default `False`)
+
+
 ---
 
 **`git-pass`** 

--- a/sidebars.js
+++ b/sidebars.js
@@ -80,7 +80,7 @@ module.exports = {
                         [
                             'guides/frameworks/pytorch/pytorch_distributed_example', 'guides/frameworks/pytorch/pytorch_matplotlib',
                             'guides/frameworks/pytorch/pytorch_mnist', 'guides/frameworks/pytorch/pytorch_tensorboard','guides/frameworks/pytorch/tensorboard_toy_pytorch',
-                            'guides/frameworks/pytorch/pytorch_tensorboardx', 'guides/frameworks/pytorch/pytorch_abseil',
+                            'guides/frameworks/pytorch/pytorch_tensorboardx', 'guides/frameworks/pytorch/pytorch_abseil', 'guides/frameworks/pytorch/model_updating',
                             {'PyTorch Notebooks': [
                                 {'Audio': ['guides/frameworks/pytorch/notebooks/audio/audio_classification_UrbanSound8K', 'guides/frameworks/pytorch/notebooks/audio/audio_preprocessing_example']},
                                 {'Image': ['guides/frameworks/pytorch/notebooks/image/hyperparameter_search', 'guides/frameworks/pytorch/notebooks/image/image_classification_CIFAR10']},
@@ -106,7 +106,7 @@ module.exports = {
 
             {'Reporting': ['guides/reporting/explicit_reporting','guides/reporting/3d_plots_reporting', 'guides/reporting/artifacts', 'guides/reporting/using_artifacts', 'guides/reporting/clearml_logging_example', 'guides/reporting/html_reporting',
                 'guides/reporting/hyper_parameters', 'guides/reporting/image_reporting', 'guides/reporting/manual_matplotlib_reporting', 'guides/reporting/media_reporting',
-                'guides/reporting/model_config', 'guides/reporting/model_updating', 'guides/reporting/pandas_reporting', 'guides/reporting/plotly_reporting',
+                'guides/reporting/model_config', 'guides/reporting/pandas_reporting', 'guides/reporting/plotly_reporting',
                 'guides/reporting/scalar_reporting', 'guides/reporting/scatter_hist_confusion_mat_reporting', 'guides/reporting/text_reporting']},
             {'Services': ['guides/services/aws_autoscaler', 'guides/services/cleanup_service', 'guides/services/slack_alerts']},
             {'Storage': ['guides/storage/examples_storagehelper']},


### PR DESCRIPTION
* Fix example link
* Rename and relocate PyTorch model logging example 
* Add `clearml-agent build` command's `--force-docker` parameter