### PR TITLE
Update clearml_serving_tutorial.md

### DIFF
--- a/docs/clearml_serving/clearml_serving_tutorial.md
+++ b/docs/clearml_serving/clearml_serving_tutorial.md
@@ -33,7 +33,7 @@ For Manual model registration see [here](#registering--deploying-new-models-manu
 Register the new Model on the Serving Service. 
 
 ```bash
-clearml-serving --id <service_id> model add --engine sklearn --endpoint "test_model_sklearn" --preprocess "examples/sklearn/preprocess.py" --name "train sklearn model" --project "serving examples"
+clearml-serving --id <service_id> model add --engine sklearn --endpoint "test_model_sklearn" --preprocess "examples/sklearn/preprocess.py" --name "train sklearn model - sklearn-model" --project "serving examples"
 ```
 
 :::info Service ID


### PR DESCRIPTION
line 36
In step 2, the provided command line has an error, in the parameter --name

The training script creates a task named "train sklearn model", but the trained model is named "train sklearn model - sklearn-model" (the sklearn-model part is because of the filename parameter used to dump the model : dump(model, filename="sklearn-model.pkl", compress=9)

The required data to put after --name is the model name