### PR TITLE
Small edits

### DIFF
--- a/docs/clearml_sdk/task_sdk.md
+++ b/docs/clearml_sdk/task_sdk.md
@@ -64,7 +64,7 @@ After invoking `Task.init` in a script, ClearML starts its automagical logging, 
         * [click](https://click.palletsprojects.com) (see code example [here](https://github.com/allegroai/clearml/blob/master/examples/frameworks/click/click_multi_cmd.py)).
         * argparse (see argparse logging example [here](../guides/reporting/hyper_parameters.md).)
         * [Python Fire](https://github.com/google/python-fire)  - see code examples [here](https://github.com/allegroai/clearml/tree/master/examples/frameworks/fire).
-        * [LightningCLI](https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.utilities.cli.html) - see code example [here](https://github.com/allegroai/clearml/blob/master/examples/frameworks/jsonargparse/pytorch_lightning_cli.py).
+        * [LightningCLI](https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.cli.LightningCLI.html) - see code example [here](https://github.com/allegroai/clearml/blob/master/examples/frameworks/jsonargparse/pytorch_lightning_cli.py).
     * TensorFlow Definitions (`absl-py`)
     * [Hydra](https://github.com/facebookresearch/hydra) - the Omegaconf which holds all the configuration files, as well as overridden values. 
 * **Models** - ClearML automatically logs and updates the models and all snapshot paths saved with the following frameworks:

--- a/docs/configs/env_vars.md
+++ b/docs/configs/env_vars.md
@@ -16,7 +16,7 @@ but can be overridden by command-line arguments.
 |Name| Description                                                                    |
 |---|--------------------------------------------------------------------------------|
 |**CLEARML_LOG_ENVIRONMENT** | List of Environment variable names. These environment variables will be logged in the ClearML task’s configuration hyperparameters `Environment` section. When executed by a ClearML agent, these values will be set in the task’s execution environment. |
-|**CLEARML_TASK_NO_REUSE** | Boolean. <br/> When set to `true`, a new task is created for every execution (see Task [reuse](../clearml_sdk/task_sdk#task-reuse).                                                              |
+|**CLEARML_TASK_NO_REUSE** | Boolean. <br/> When set to `true`, a new task is created for every execution (see Task [reuse](../clearml_sdk/task_sdk#task-reuse)).                                                              |
 |**CLEARML_CACHE_DIR** | Set the path for the ClearML cache directory, where ClearML stores all downloaded content.   |
 |**CLEARML_DOCKER_IMAGE** | Sets the default docker image to use when running an agent in [Docker mode](../clearml_agent.md#docker-mode).  |
 |**CLEARML_LOG_LEVEL** | Sets the ClearML package's log verbosity. Log levels adhere to [Python log levels](https://docs.python.org/3/library/logging.config.html#configuration-file-format): CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -286,7 +286,7 @@ to reproduce. You can see uncommitted changes in the ClearML Web UI, in the EXEC
 Yes! ClearML provides multiple ways to configure your task and track your parameters! 
 
 In addition to argparse, ClearML also automatically captures and tracks command line parameters created using [click](https://click.palletsprojects.com/), 
-[Python Fire](https://github.com/google/python-fire), and/or [LightningCLI](https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.utilities.cli.html).
+[Python Fire](https://github.com/google/python-fire), and/or [LightningCLI](https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.cli.LightningCLI.html).
 
 ClearML also supports tracking code-level configuration dictionaries using the [Task.connect](references/sdk/task.md#connect) method.
 

--- a/docs/fundamentals/hyperparameters.md
+++ b/docs/fundamentals/hyperparameters.md
@@ -25,7 +25,7 @@ the following types of parameters:
   * [click](https://click.palletsprojects.com) - see code example [here](https://github.com/allegroai/clearml/blob/master/examples/frameworks/click/click_multi_cmd.py).
   * [argparse](https://docs.python.org/3/library/argparse.html) - see code example [here](../guides/frameworks/pytorch/pytorch_tensorboardx.md).
   * [Python Fire](https://github.com/google/python-fire)  - see code examples [here](https://github.com/allegroai/clearml/tree/master/examples/frameworks/fire).
-  * [LightningCLI](https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.utilities.cli.html) - see code example [here](https://github.com/allegroai/clearml/blob/master/examples/frameworks/jsonargparse/pytorch_lightning_cli.py).
+  * [LightningCLI](https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.cli.LightningCLI.html) - see code example [here](https://github.com/allegroai/clearml/blob/master/examples/frameworks/jsonargparse/pytorch_lightning_cli.py).
 * TensorFlow Definitions (`absl-py`). See examples of ClearML's automatic logging of TF Defines:
     * [TensorFlow MNIST](../guides/frameworks/tensorflow/tensorflow_mnist.md)
     * [TensorBoard PR Curve](../guides/frameworks/tensorflow/tensorboard_pr_curve.md)
@@ -66,7 +66,7 @@ connect Python objects and configuration objects, as well as manually set and up
 
 #### Connecting Python Objects 
 Users can directly connect Python objects, such as dictionaries and custom classes, to tasks, using the 
-[Task.connect](../references/sdk/task.md#connect) method. Once objects are connected to a task, all object elements 
+[`Task.connect`](../references/sdk/task.md#connect) method. Once objects are connected to a task, all object elements 
 (e.g. class members, dictionary key-values pairs) are automatically logged by ClearML. Additionally, ClearML tracks these 
 values as they change through your code.
 
@@ -75,12 +75,12 @@ pair in a parameter dictionary).
 
 #### Connecting Configuration Objects
 Configuration objects are dictionaries or configuration files connected to the task using the 
-[Task.connect_configuration](../references/sdk/task.md#connect_configuration) method. With this method, configuration 
+[`Task.connect_configuration`](../references/sdk/task.md#connect_configuration) method. With this method, configuration 
 objects are saved as blobs i.e. ClearML is not aware of their internal structure.
 
 #### Setting and Updating Parameters
-ClearML provides methods to set and update task parameters manually. Use the [Task.set_parameters](../references/sdk/task.md#set_parameters) 
-method to define parameters manually. To update the parameters in an experiment, use the [Task.set_parameters_as_dict](../references/sdk/task.md#set_parameters_as_dict) 
+ClearML provides methods to set and update task parameters manually. Use the [`Task.set_parameters`](../references/sdk/task.md#set_parameters) 
+method to define parameters manually. To update the parameters in an experiment, use the [`Task.set_parameters_as_dict`](../references/sdk/task.md#set_parameters_as_dict) 
 method. The `set_parameters_as_dict` method updates parameters while the `set_parameters` method overrides the parameters.
 
 ClearML does not automatically track changes to explicitly set parameters.
@@ -89,14 +89,14 @@ ClearML does not automatically track changes to explicitly set parameters.
 User properties do not impact tasks execution and so can be modified at any stage. They offer the convenience of setting 
 helpful values which then be displayed in the [experiment table](../webapp/webapp_exp_table.md) (i.e. customize columns), 
 making it easier to search / filter experiments. Add user properties to an experiment with the 
-[Task.set_user_properties](../references/sdk/task.md#set_user_properties) method.
+[`Task.set_user_properties`](../references/sdk/task.md#set_user_properties) method.
 
 ### Accessing Parameters
 
 ClearML provides methods to directly access a task’s logged parameters.
 
 To get all of a task's parameters and properties (hyperparameters, configuration objects, and user properties), use the 
-[Task.get_parameters](../references/sdk/task.md#get_parameters) method, which will return a dictionary with the parameters, 
+[`Task.get_parameters`](../references/sdk/task.md#get_parameters) method, which will return a dictionary with the parameters, 
 including their sub-sections (see [WebApp sections](#webapp-interface) below). 
 
 ## WebApp Interface

--- a/docs/fundamentals/logger.md
+++ b/docs/fundamentals/logger.md
@@ -116,9 +116,9 @@ Credentials for the destination storage are specified in the [ClearML configurat
 
 ### Automatic Logging Settings
 The Logger class provides methods for fine-tuning ClearML's automatic logging behavior with Matplotlib and Tensorboard. 
-For example, use the [Logger.matplotlib_force_report_non_interactive](../references/sdk/logger.md#loggermatplotlib_force_report_non_interactive) 
-class method to control how matplotlib objects are logged. See the [Logger.tensorboard_auto_group_scalars](../references/sdk/logger.md#loggertensorboard_auto_group_scalars) 
-and [Logger.tensorboard_single_series_per_graph](../references/sdk/logger.md#loggertensorboard_single_series_per_graph) 
+For example, use the [`Logger.matplotlib_force_report_non_interactive`](../references/sdk/logger.md#loggermatplotlib_force_report_non_interactive) 
+class method to control how matplotlib objects are logged. See the [`Logger.tensorboard_auto_group_scalars`](../references/sdk/logger.md#loggertensorboard_auto_group_scalars) 
+and [`Logger.tensorboard_single_series_per_graph`](../references/sdk/logger.md#loggertensorboard_single_series_per_graph) 
 class methods.  
 
 

--- a/docs/fundamentals/projects.md
+++ b/docs/fundamentals/projects.md
@@ -46,7 +46,7 @@ Projects can also be created using the [`projects.create`](../references/api/pro
 
 ### View All Projects in System
 
-To view all projects in the system, use the `Task` class method `get_projects`:
+To view all projects in the system, use the `Task.get_projects` class method:
 
 ```python
 project_list = Task.get_projects()


### PR DESCRIPTION
* Fix broken links
* Add backticks to python methods
* Add missing parentheses 
* `Task` class method `get_projects` >>> `Task.get_projects` class method