### PR TITLE
Fix a swap of text for OutputModel and Model

### DIFF
--- a/docs/clearml_sdk/model_sdk.md
+++ b/docs/clearml_sdk/model_sdk.md
@@ -5,9 +5,9 @@ title: Model
 The following page provides an overview of the basic Pythonic interface to ClearML Models.
 
 ClearML provides the following classes to work with models:
-* `Model` - represents an experiment's output model (training results). An OutputModel is always connected to a [task](../fundamentals/task.md). 
+* `Model` - represents a ClearML model, regardless of any task connection.
 * `InputModel` - represents an existing ClearML model to be used in an experiment.
-* `OutputModel` - represents a ClearML model, regardless of any task connection.
+* `OutputModel` - represents an experiment's output model (training results). An OutputModel is always connected to a [task](../fundamentals/task.md). 
 
 ## Output Models
 


### PR DESCRIPTION
Fixes the swap in description, that is mentioned in https://github.com/allegroai/clearml-docs/issues/472
Does not fix the other aspect of the issue 472 though, because I do not know the answers to those.