### PR TITLE
Add Dependabot update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13763,8 +13763,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "license": "MIT",
+      "version": "5.76.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.2.tgz",
+      "integrity": "sha512-Th05ggRm23rVzEOlX8y67NkYCHa9nTNcwHPBhdg+lKG+mtiW7XgggjAeeLnADAe7mLjJ6LUNfgHAuRRh+Z6J7w==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -22952,7 +22953,9 @@
       "version": "3.0.1"
     },
     "webpack": {
-      "version": "5.75.0",
+      "version": "5.76.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.2.tgz",
+      "integrity": "sha512-Th05ggRm23rVzEOlX8y67NkYCHa9nTNcwHPBhdg+lKG+mtiW7XgggjAeeLnADAe7mLjJ6LUNfgHAuRRh+Z6J7w==",
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",


### PR DESCRIPTION
Bump webpack from 5.75.0 to 5.76.2 (#32)
Bumps [webpack](https://github.com/webpack/webpack) from 5.75.0 to 5.76.2.
- [Release notes](https://github.com/webpack/webpack/releases)
- [Commits](https://github.com/webpack/webpack/compare/v5.75.0...v5.76.2)

---
updated-dependencies:
- dependency-name: webpack dependency-type: indirect ...