### PR TITLE
Correct location of fileserver

### DIFF
--- a/docs/deploying_clearml/clearml_server_aws_ec2_ami.md
+++ b/docs/deploying_clearml/clearml_server_aws_ec2_ami.md
@@ -65,7 +65,7 @@ The pre-built ClearML Server storage configuration is the following:
 
 * MongoDB: `/opt/clearml/data/mongo_4/`
 * Elasticsearch: `/opt/clearml/data/elastic_7/`
-* File Server: `/mnt/fileserver/`
+* File Server: `/opt/clearml/fileserver/`
 
 
 ## Backing Up and Restoring Data and Configuration


### PR DESCRIPTION
I noticed that the fileserver location [in the docs ](http://localhost:3000/docs/deploying_clearml/clearml_server_aws_ec2_ami#storage-configuration) was incorrect. 

It should be `/opt/clearml/fileserver`. 

I verified this by doing a fresh install of a server.


I believe `/mnt/fileserver` is the mapping in the internal mounting point for docker as per:

https://github.com/allegroai/clearml-server/blob/2263e7cc1e72ec5136d4f37b94e4fda787fb2128/docker/docker-compose.yml#L13