### PR TITLE
Incorrect location of fileserver on AWS EC2 AMIs page

### DIFF
--- a/docs/deploying_clearml/clearml_server_aws_ec2_ami.md
+++ b/docs/deploying_clearml/clearml_server_aws_ec2_ami.md
@@ -65,7 +65,7 @@ The pre-built ClearML Server storage configuration is the following:
 
 * MongoDB: `/opt/clearml/data/mongo_4/`
 * Elasticsearch: `/opt/clearml/data/elastic_7/`
-* File Server: `/mnt/fileserver/`
+* File Server: `/opt/clearml/data/fileserver/`
 
 
 ## Backing Up and Restoring Data and Configuration


### PR DESCRIPTION
The location of the file server in [AWS EC2 AMIs page](https://clear.ml/docs/latest/docs/deploying_clearml/clearml_server_aws_ec2_ami#storage-configuration) is incorrect.

It should read `/opt/clearml/data/fileserver`.

I was able to verify this with a fresh server installation.

`/mnt/fileserver` corresponds to the internal docker volume mapping as it can be seen here:
https://github.com/allegroai/clearml-server/blob/2263e7cc1e72ec5136d4f37b94e4fda787fb2128/docker/docker-compose.yml#L13