### PR TITLE
Remove info about dynamic server variables from client variable page

### DIFF
--- a/docs/configs/env_vars.md
+++ b/docs/configs/env_vars.md
@@ -4,9 +4,6 @@ title: Environment Variables
 
 This page lists the available environment variables for configuring ClearML. 
 
-In addition to the environment variables listed below, ClearML also supports **dynamic environment variables** to override 
-any configuration option that appears in the configuration files. For more information, see [Dynamic Environment Variables](../deploying_clearml/clearml_server_config.md#dynamic-environment-variables).
-
 :::info
 ClearML's environment variables override the clearml.conf file, SDK, and [configuration vault](../webapp/settings/webapp_settings_profile.md#configuration-vault), 
 but can be overridden by command-line arguments. 


### PR DESCRIPTION
Related issue: https://github.com/clearml/clearml-docs/issues/1211 