### PR TITLE
Add Backblaze B2 to the Non-AWS S3-compatible endpoints section

### DIFF
--- a/docs/integrations/storage.md
+++ b/docs/integrations/storage.md
@@ -94,7 +94,7 @@ sdk {
 
 #### Non-AWS Endpoints
 ClearML supports any S3-compatible services, such as [MinIO](https://github.com/minio/minio) and
-[Backblaze B2](https://www.backblaze.com/cloud-storage) as well as other cloud-based or locally
+[Backblaze B2](https://www.backblaze.com/docs/cloud-storage-s3-compatible-api) as well as other cloud-based or locally
 deployed storage services. For non-AWS endpoints, use a configuration like this:
 
 ```

--- a/docs/integrations/storage.md
+++ b/docs/integrations/storage.md
@@ -93,8 +93,9 @@ sdk {
 ``` 
 
 #### Non-AWS Endpoints
-ClearML supports any S3-compatible services, such as [MinIO](https://github.com/minio/minio) as well as other 
-cloud-based or locally deployed storage services. For non-AWS endpoints, use a configuration like this:
+ClearML supports any S3-compatible services, such as [MinIO](https://github.com/minio/minio) and
+[Backblaze B2](https://www.backblaze.com/cloud-storage) as well as other cloud-based or locally
+deployed storage services. For non-AWS endpoints, use a configuration like this:
 
 ```
 sdk {


### PR DESCRIPTION
Adds Backblaze B2 to the existing "Non-AWS Endpoints" section in `docs/integrations/storage.md`, listing it as a supported S3-compatible service alongside the MinIO example already in that prose.

Per @ainoam's review:

- No B2-specific subsection. B2's S3-compatible API works against the existing `sdk.aws.s3.credentials` block with no special configuration, so it belongs inline in the generic non-AWS prose rather than in its own block (consistent with how the section already treats other providers).
- The "Backblaze B2" link points to the Backblaze S3-compatible API documentation (https://www.backblaze.com/docs/cloud-storage-s3-compatible-api), which describes the S3 compatibility of the service rather than a commercial landing page or a code repository.

No structural changes. All existing examples and notes (AWS S3, MinIO, Dell PowerScale) are untouched.
